### PR TITLE
Yomichan support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
 name = "kobo_jp_dict"
 version = "0.1.0"
 dependencies = [
@@ -151,6 +157,7 @@ dependencies = [
  "flate2",
  "quick-xml",
  "regex",
+ "serde_json",
  "tempfile",
  "unicode_categories",
  "zip",
@@ -290,6 +297,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "serde"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "2", features = ["wrap_help"] }
 flate2 = "1"
 quick-xml = "0.22"
 regex = "1.5"
+serde_json = "1.0"
 tempfile = "3"
 unicode_categories = "0.1"
 zip = { git = "https://github.com/cessen/zip", branch = "raw_filename" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,17 +390,18 @@ fn generate_definition_text(
 ) -> String {
     let mut text = String::new();
 
-    text.push_str("<p style=\"margin-top: 0.7em; margin-bottom: 0.7em;\">");
-    for (i, def) in jm_entry.definitions.iter().enumerate() {
-        text.push_str(&format!("<b>{}.</b> {}<br/>", i + 1, def));
+    text.push_str("<p style=\"margin-top: 0.7em; margin-bottom: 0.7em;\"><ol>");
+    for def in jm_entry.definitions.iter() {
+        text.push_str(&format!("<li>{}</li>", def));
     }
-    text.push_str("</p>");
+    text.push_str("</ol></p>");
 
     for entry in yomi_entries.iter() {
-        for (i, def) in entry.definitions.iter().enumerate() {
-            text.push_str(&format!("<b>{}.</b> {}<br/>", i + 1, def));
+        text.push_str(&format!("<p>{}:<br/><ol>", entry.dict_name));
+        for def in entry.definitions.iter() {
+            text.push_str(&format!("<li>{}</li>", def));
         }
-        text.push_str("</p>");
+        text.push_str("</ol></p>");
     }
 
     for kobo_entry in kobo_entries.iter().take(1) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,7 @@ fn main() -> io::Result<()> {
                 item,
             ));
             entries.push(kobo::Entry {
-                keys: vec![(writing.clone(), 9999)],
+                keys: vec![(writing.clone(), std::u32::MAX)], // Always sort names last.
                 definition: entry_text,
             });
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,15 @@ fn main() -> io::Result<()> {
     // TODO
 
     // Kanji entries.
-    // TODO
+    for (kanji, item) in yomi_kanji_table.iter() {
+        let mut entry_text: String = "<hr/>".into();
+        entry_text.push_str(&generate_kanji_entry_text(&item[0]));
+
+        entries.push(kobo::Entry {
+            keys: vec![(kanji.clone(), 0)],
+            definition: entry_text,
+        });
+    }
 
     entries.sort_by_key(|a| a.keys[0].0.len());
 
@@ -569,6 +577,45 @@ fn generate_lookup_keys(jm_entry: &WordEntry) -> Vec<(String, u32)> {
     keys.sort_by_key(|a| (a.1, a.0.len(), a.0.clone()));
     keys.dedup();
     keys
+}
+
+fn generate_kanji_entry_text(entry: &yomichan::KanjiEntry) -> String {
+    let mut text = String::new();
+
+    text.push_str("<p style=\"margin-left: 2.5em; margin-bottom: 0.7em; text-indent: -2.5em;\"><span style=\"font-size: 1.5em;\">");
+    text.push_str(&entry.kanji);
+    if !entry.meanings.is_empty() {
+        text.push_str("</span>　");
+        for meaning in entry.meanings.iter() {
+            text.push_str(meaning);
+            text.push_str(", ");
+        }
+        text.pop();
+        text.pop();
+    }
+    text.push_str("</p>");
+
+    if !entry.onyomi.is_empty() {
+        text.push_str("<p style=\"margin-left: 2.5em; text-indent: -2.5em;\">音:　");
+        for onyomi in entry.onyomi.iter() {
+            text.push_str(onyomi);
+            text.push_str("／");
+        }
+        text.pop();
+        text.push_str("</p>");
+    }
+
+    if !entry.kunyomi.is_empty() {
+        text.push_str("<p style=\"margin-left: 2.5em; text-indent: -2.5em;\">訓:　");
+        for kunyomi in entry.kunyomi.iter() {
+            text.push_str(kunyomi);
+            text.push_str("／");
+        }
+        text.pop();
+        text.push_str("</p>");
+    }
+
+    text
 }
 
 /// Panics if the bytes aren't utf8.

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::io::BufReader;
 mod jmdict;
 mod kobo;
 mod kobo_ja;
+mod yomichan;
 
 use jmdict::{ConjugationClass, PartOfSpeech, WordEntry};
 
@@ -46,6 +47,15 @@ fn main() -> io::Result<()> {
                 .help("Path to the Kobo Japanese-Japanese dictionary file if available.  Will add native Japanese definitions to matching entries")
                 .value_name("PATH")
                 .takes_value(true),
+        )
+        .arg(
+            clap::Arg::with_name("yomichan_dict")
+                .short("y")
+                .long("yomichan")
+                .help("Path to a zipped Yomichan dictionary.  Will add either additional definitions to existing entries or completely new entries, depending the dictionary")
+                .value_name("PATH")
+                .takes_value(true)
+                .multiple(true),
         )
         .arg(
             clap::Arg::with_name("katakana_pronunciation")
@@ -121,6 +131,13 @@ fn main() -> io::Result<()> {
             entry_list.push(entry);
         }
         println!("Kobo dictionary entries: {}", kobo_table.len());
+    }
+
+    // Open and parse Yomichan dictionaries.
+    if let Some(paths) = matches.values_of("yomichan_dict") {
+        for path in paths {
+            yomichan::parse(std::path::Path::new(path), true).unwrap();
+        }
     }
 
     //----------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,10 +141,13 @@ fn main() -> io::Result<()> {
     let mut yomi_kanji_table: HashMap<String, Vec<yomichan::KanjiEntry>> = HashMap::new(); // Kanji
     if let Some(paths) = matches.values_of("yomichan_dict") {
         for path in paths {
+            let mut entry_count = 0usize;
+
             let (mut word_entries, mut name_entries, mut kanji_entries) =
                 yomichan::parse(std::path::Path::new(path)).unwrap();
 
             // Put all of the word entries into the terms table.
+            entry_count += word_entries.len();
             for entry in word_entries.drain(..) {
                 let reading = strip_non_kana(&hiragana_to_katakana(entry.reading.trim()));
                 let writing: String = entry.writing.trim().into();
@@ -162,6 +165,7 @@ fn main() -> io::Result<()> {
             }
 
             // Put all of the name entries into the names table.
+            entry_count += name_entries.len();
             for entry in name_entries.drain(..) {
                 let reading = strip_non_kana(&hiragana_to_katakana(entry.reading.trim()));
                 let writing: String = entry.writing.trim().into();
@@ -179,6 +183,7 @@ fn main() -> io::Result<()> {
             }
 
             // Put all of the kanji entries into the kanji table.
+            entry_count += kanji_entries.len();
             for entry in kanji_entries.drain(..) {
                 let entry_list = yomi_kanji_table
                     .entry(entry.kanji.clone())
@@ -186,11 +191,7 @@ fn main() -> io::Result<()> {
                 entry_list.push(entry);
             }
 
-            println!(
-                "    {} entries: {}",
-                path,
-                word_entries.len() + name_entries.len() + kanji_entries.len()
-            );
+            println!("    {} entries: {}", path, entry_count);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,8 @@ fn main() -> io::Result<()> {
     //----------------------------------------------------------------
     // Read in all the files.
 
+    println!("Loading dictionaries...");
+
     // Open and parse the JMDict file.
     let mut jm_table: HashMap<(String, String), Vec<WordEntry>> = HashMap::new(); // (Kanji, Kana)
     if let Some(path) = matches.value_of("jmdict") {
@@ -92,7 +94,7 @@ fn main() -> io::Result<()> {
             let e = jm_table.entry((writing, reading)).or_insert(Vec::new());
             e.push(entry);
         }
-        println!("JMDict entries: {}", jm_table.len());
+        println!("    JMDict entries: {}", jm_table.len());
     }
 
     // Open and parse the pitch accent file.
@@ -117,7 +119,7 @@ fn main() -> io::Result<()> {
 
             pa_table.insert((writing, reading), accents);
         }
-        println!("Pitch Accent entries: {}", pa_table.len());
+        println!("    Pitch Accent entries: {}", pa_table.len());
     }
 
     // Open and parse the Kobo Japanese-Japanese dictionary.
@@ -130,13 +132,19 @@ fn main() -> io::Result<()> {
                 .or_insert(Vec::new());
             entry_list.push(entry);
         }
-        println!("Kobo dictionary entries: {}", kobo_table.len());
+        println!("    Kobo dictionary entries: {}", kobo_table.len());
     }
 
     // Open and parse Yomichan dictionaries.
     if let Some(paths) = matches.values_of("yomichan_dict") {
         for path in paths {
-            yomichan::parse(std::path::Path::new(path), true).unwrap();
+            let (word_entries, name_entries, kanji_entries) =
+                yomichan::parse(std::path::Path::new(path)).unwrap();
+            println!(
+                "    {} entries: {}",
+                path,
+                word_entries.len() + name_entries.len() + kanji_entries.len()
+            );
         }
     }
 

--- a/src/yomichan.rs
+++ b/src/yomichan.rs
@@ -169,6 +169,7 @@ pub fn parse(path: &Path) -> std::io::Result<(Vec<TermEntry>, Vec<TermEntry>, Ve
                         .unwrap()
                         .split(" ")
                         .map(|s| s.trim().into())
+                        .filter(|s: &String| !s.is_empty())
                         .collect(),
                     kunyomi: item
                         .get(2)
@@ -177,6 +178,7 @@ pub fn parse(path: &Path) -> std::io::Result<(Vec<TermEntry>, Vec<TermEntry>, Ve
                         .unwrap()
                         .split(" ")
                         .map(|s| s.trim().into())
+                        .filter(|s: &String| !s.is_empty())
                         .collect(),
                     meanings: item
                         .get(4)
@@ -185,6 +187,7 @@ pub fn parse(path: &Path) -> std::io::Result<(Vec<TermEntry>, Vec<TermEntry>, Ve
                         .unwrap()
                         .iter()
                         .map(|s| s.as_str().unwrap().trim().into())
+                        .filter(|s: &String| !s.is_empty())
                         .collect(),
                 };
                 kanji_entries.push(entry);

--- a/src/yomichan.rs
+++ b/src/yomichan.rs
@@ -1,4 +1,4 @@
-//! Parses the Kobo's Japanse-Japanese dictionary.
+//! Parses Yomichan .zip dictionaries.
 
 use std::collections::HashMap;
 use std::fs::File;

--- a/src/yomichan.rs
+++ b/src/yomichan.rs
@@ -1,0 +1,170 @@
+//! Parses the Kobo's Japanse-Japanese dictionary.
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::{hiragana_to_katakana, strip_non_kana};
+
+//----------------------------------------------------------------
+// Entry type for words.
+#[derive(Clone, Debug)]
+pub struct TermEntry {
+    pub writing: String,
+    pub reading: String,
+    pub definitions: Vec<String>,
+    pub infl: InflectionType,
+    pub tags: Vec<String>,
+    pub commonness: i32, // Higher is more common.
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum InflectionType {
+    VerbIchidan,
+    VerbGodan,
+    VerbSuru,
+    VerbKuru,
+    IAdjective,
+    None,
+}
+
+//----------------------------------------------------------------
+// Entry type for kanji.
+#[derive(Clone, Debug)]
+pub struct KanjiEntry {
+    pub kanji: char,
+    pub readings: Vec<String>,
+    pub meanings: Vec<String>,
+}
+
+//----------------------------------------------------------------
+
+pub fn parse(
+    path: &Path,
+    print_progress: bool,
+) -> std::io::Result<(Vec<TermEntry>, Vec<TermEntry>, Vec<KanjiEntry>)> // (words, names, kanji)
+{
+    let mut zip_in = zip::ZipArchive::new(BufReader::new(File::open(path)?))?;
+
+    let mut text = String::new();
+
+    // Load index.json for meta-data about the dictionary.
+    let index_json: Value = {
+        text.clear();
+        zip_in
+            .by_name("index.json")
+            .expect("Yomichan dictionary isn't valid: no index.json.")
+            .read_to_string(&mut text)
+            .expect("Yomichan dictionary isn't valid: invalid json.");
+        serde_json::from_str(&text).expect("Yomichan dictionary isn't valid: invalid json.")
+    };
+
+    // Check the format version.
+    match index_json.get("format") {
+        Some(Value::Number(version)) if version.as_i64() == Some(3) => {}
+        _ => panic!("Yomichan dictionaries other than format version 3 are not supported."),
+    }
+
+    // Get the normalized dictionary title.
+    let dictionary_title: String = index_json
+        .get("title")
+        .expect("Yomichan dictionary isn't valid: index in unexpected format.")
+        .as_str()
+        .expect("Yomichan dictionary isn't valid: index in unexpected format.")
+        .to_lowercase()
+        .split("(")
+        .nth(0)
+        .unwrap()
+        .trim()
+        .into();
+
+    // Is this a name dictionary?
+    let is_name_dict = match dictionary_title.as_str() {
+        "jmnedict" => true,
+        _ => false,
+    };
+
+    // Loop through the bank-json files in the zip and build our entry list(s).
+    let mut term_entries = Vec::new();
+    let mut name_entries = Vec::new();
+    let mut kanji_entries = Vec::new();
+    for i in 0..zip_in.len() {
+        if print_progress {
+            print!("\rLoading: {}/{}", i + 1, zip_in.len());
+        }
+
+        // Open the file.
+        let mut f = zip_in.by_index(i).unwrap();
+        let filename: String = std::str::from_utf8(f.name_raw()).unwrap().into();
+        if !filename.ends_with(".json") {
+            continue;
+        }
+
+        // Load the json data.
+        text.clear();
+        f.read_to_string(&mut text)
+            .expect("Yomichan dictionary isn't valid: invalid json.");
+        let json: Value =
+            serde_json::from_str(&text).expect("Yomichan dictionary isn't valid: invalid json.");
+
+        // Parse the json into entries.
+        if filename.starts_with("term_bank_") {
+            // It's a term bank.
+            for item in json.as_array().unwrap().iter() {
+                let entry = TermEntry {
+                    writing: item.get(0).unwrap().as_str().unwrap().into(),
+                    reading: item.get(1).unwrap().as_str().unwrap().into(),
+                    tags: item
+                        .get(2)
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .split(" ")
+                        .map(|s| s.into())
+                        .collect(),
+                    infl: match item.get(3).unwrap().as_str().unwrap().trim() {
+                        "v1" => InflectionType::VerbIchidan,
+                        "v5" => InflectionType::VerbGodan,
+                        "vs" => InflectionType::VerbSuru,
+                        "vk" => InflectionType::VerbKuru,
+                        "adj-i" => InflectionType::IAdjective,
+                        _ => InflectionType::None,
+                    },
+                    commonness: item.get(4).unwrap().as_i64().unwrap() as i32,
+                    definitions: vec![item
+                        .get(5)
+                        .unwrap()
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|d| {
+                            if let Some(s) = d.as_str() {
+                                s.trim()
+                            } else {
+                                // Ignore the complex structured defintions for now.
+                                // TODO: handle this properly.
+                                ""
+                            }
+                        })
+                        .collect::<Vec<&str>>()
+                        .join("; ")],
+                };
+
+                if is_name_dict {
+                    name_entries.push(entry);
+                } else {
+                    term_entries.push(entry);
+                }
+            }
+        } else if filename.starts_with("kanji_bank_") {
+            // It's a kanji bank.
+            for item in json.as_array().unwrap().iter() {}
+        }
+    }
+    println!();
+
+    Ok((term_entries, name_entries, kanji_entries))
+}

--- a/src/yomichan.rs
+++ b/src/yomichan.rs
@@ -7,8 +7,6 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use crate::{hiragana_to_katakana, strip_non_kana};
-
 //----------------------------------------------------------------
 // Entry type for words.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Add support for Yomichan dictionaries, including:

- Japanese-English dictionaries.
- Japanese-Japanese dictionaries.
- Name dictionaries.
- Kanji dictionaries.

Some basic filtering of the definition text is attempted, to prevent:
1. Redundant headers from appearing in the definitions (we already have our own entry headers).
2. Japanese -> English entries from Japanese-Japanese dictionaries (yes, this exists), since that's likely not what people want from a Japanese-Japanese dictionary.  If the user wants Japanese-English entries, they can include an actual Japanese-English dictionary.